### PR TITLE
Clean up some peer dependency warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export interface AbstractStore<RootState> {
 }
 ```
 
-Both `NgRedux<T>` and `Redux.Store<T>` conform to this shape. If you have something
+Both `NgRedux<T>` and `Redux.Store<T>` conform to this shape. If you have a more
 complicated use-case that is not covered here, you could even create your own store
 shim as long as it conforms to the shape of `AbstractStore<RootState>`.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redux-logger": "^2.6.1",
     "reflect-metadata": "^0.1.3",
     "rimraf": "^2.5.4",
-    "rxjs": "^5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "ts-helpers": "^1.1.1",
     "typings": "^1.0",
     "webpack": "1.13.1",
@@ -44,11 +44,8 @@
     "@angular/common": "^2.0.0-rc.5",
     "@angular/compiler": "^2.0.0-rc.5",
     "@angular/core": "^2.0.0-rc.5",
-    "@angular/forms": "^0.3.0",
-    "ng2-redux": "^3.3.2",
-    "redux": "^3.0",
-    "rxjs": "^5.0.0-beta.6",
-    "zone.js": "^0.6.12"
+    "@angular/forms": "^2.0.0-rc.5",
+    "redux": "^3.0"
   },
   "engines": {
     "node": ">=6.0"


### PR DESCRIPTION
We don't need to transitively list rxjs and zone as peer deps: Angular itself lists them as such. We've cleaned this up in ng2-redux too.

Since this can be used with a raw Redux store, do we need Ng2 Redux to be a peer dep?

Fixed a typo in the readme.
